### PR TITLE
Latest BC library for gzip support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ itsdangerous==0.24
 requests==2.11.1
 streql==3.0.2
 python-dotenv==0.6.0
-bigcommerce==0.17.0
+bigcommerce==0.17.1
 Flask-SQLAlchemy==2.1
 gunicorn==19.6.0
 psycopg2==2.6.2


### PR DESCRIPTION
BC python library 0.17.1 supports gzip for OAuth API connections, in the interest of showing best practices I am also updating the sample app.