### PR TITLE
Python 3.6.0

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.0


### PR DESCRIPTION
Updating runtime.txt to Heroku's currently supported version of python3.